### PR TITLE
Add WoskiCart admin dashboard frontend

### DIFF
--- a/admin/assets/css/custom.css
+++ b/admin/assets/css/custom.css
@@ -1,0 +1,1 @@
+/* Override default styles here */

--- a/admin/assets/css/style.css
+++ b/admin/assets/css/style.css
@@ -1,0 +1,72 @@
+:root {
+  --wc-primary: #0d6efd;
+  --wc-secondary: #6c757d;
+  --wc-bg: #f8f9fa;
+  --wc-text: #212529;
+}
+
+[data-theme="dark"] {
+  --wc-primary: #0d6efd;
+  --wc-secondary: #6c757d;
+  --wc-bg: #212529;
+  --wc-text: #f8f9fa;
+}
+
+[data-theme="custom"] {
+  --wc-primary: #4caf50;
+  --wc-secondary: #ff9800;
+  --wc-bg: #ffffff;
+  --wc-text: #333333;
+}
+
+body {
+  background-color: var(--wc-bg);
+  color: var(--wc-text);
+  font-family: "Roboto", Arial, sans-serif;
+}
+
+.sidebar {
+  width: 250px;
+  min-height: 100vh;
+  background: var(--wc-primary);
+  color: #fff;
+  transition: all 0.3s;
+}
+.sidebar.collapsed {
+  margin-left: -250px;
+}
+.sidebar a {
+  color: #fff;
+  text-decoration: none;
+}
+
+#page-content-wrapper {
+  flex: 1;
+  background: var(--wc-bg);
+}
+
+.navbar {
+  background: var(--wc-primary);
+}
+.navbar .navbar-brand, .navbar .nav-link, .navbar .navbar-text {
+  color: #fff;
+}
+
+.card {
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  border: none;
+}
+.card:hover {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.theme-switcher .dropdown-item {
+  cursor: pointer;
+}
+
+.alerts-container {
+  position: fixed;
+  top: 70px;
+  right: 20px;
+  z-index: 1055;
+}

--- a/admin/assets/js/script.js
+++ b/admin/assets/js/script.js
@@ -1,0 +1,91 @@
+$(function() {
+  function applyTheme(theme) {
+    $('body').attr('data-theme', theme);
+    localStorage.setItem('wcTheme', theme);
+  }
+
+  var savedTheme = localStorage.getItem('wcTheme') || 'default';
+  applyTheme(savedTheme);
+
+  $('.theme-switcher .dropdown-item').on('click', function() {
+    var theme = $(this).data('theme');
+    applyTheme(theme);
+  });
+
+  $('#sidebarToggle').on('click', function() {
+    $('#sidebar').toggleClass('collapsed');
+  });
+
+  $('.alert-trigger').on('click', function() {
+    var type = $(this).data('type');
+    var alert = $('<div class="alert alert-' + type + ' alert-dismissible fade show" role="alert">'
+      + 'This is a ' + type + ' alert!' +
+      '<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>');
+    $('.alerts-container').append(alert);
+  });
+
+  // Dashboard charts
+  if (document.getElementById('salesChart')) {
+    new Chart(document.getElementById('salesChart'), {
+      type: 'line',
+      data: {
+        labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+        datasets: [{
+          label: 'Sales',
+          data: [12, 19, 3, 5, 2, 3, 9],
+          borderColor: 'rgba(13,110,253,0.5)',
+          backgroundColor: 'rgba(13,110,253,0.2)',
+          tension: .4
+        }]
+      }
+    });
+  }
+
+  if (document.getElementById('ordersStatusChart')) {
+    new Chart(document.getElementById('ordersStatusChart'), {
+      type: 'doughnut',
+      data: {
+        labels: ['Pending', 'Paid', 'Shipped', 'Completed'],
+        datasets: [{
+          data: [30, 50, 20, 10],
+          backgroundColor: ['#ffc107', '#0d6efd', '#17a2b8', '#28a745']
+        }]
+      }
+    });
+  }
+
+  if (document.getElementById('topProductsChart')) {
+    new Chart(document.getElementById('topProductsChart'), {
+      type: 'bar',
+      data: {
+        labels: ['Product A', 'Product B', 'Product C', 'Product D'],
+        datasets: [{
+          label: 'Sales',
+          data: [65, 59, 80, 81],
+          backgroundColor: 'rgba(13,110,253,0.5)'
+        }]
+      }
+    });
+  }
+
+  if (document.getElementById('customersChart')) {
+    new Chart(document.getElementById('customersChart'), {
+      type: 'bar',
+      data: {
+        labels: ['USA', 'UK', 'Canada', 'Germany'],
+        datasets: [{
+          label: 'Customers',
+          data: [50, 40, 30, 20],
+          backgroundColor: 'rgba(40,167,69,0.5)'
+        }]
+      }
+    });
+  }
+
+  // Charts page filters
+  $('.chart-filter .btn').on('click', function(){
+    $('.chart-filter .btn').removeClass('active');
+    $(this).addClass('active');
+    // Placeholder: would reload charts with new data
+  });
+});

--- a/admin/boilerplate.php
+++ b/admin/boilerplate.php
@@ -1,0 +1,4 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3">Boilerplate Page</h1>
+<p>Use this starter layout for new pages.</p>
+<?php include 'partials/footer.php'; ?>

--- a/admin/categories.php
+++ b/admin/categories.php
@@ -1,0 +1,12 @@
+<?php include 'partials/header.php'; ?>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3">Categories</h1>
+  <a href="category-form.php" class="btn btn-primary">Add Category</a>
+</div>
+<table class="table table-bordered table-striped">
+  <thead><tr><th>ID</th><th>Name</th><th></th></tr></thead>
+  <tbody>
+    <tr><td>1</td><td>Electronics</td><td><a href="category-form.php" class="btn btn-sm btn-secondary">Edit</a></td></tr>
+  </tbody>
+</table>
+<?php include 'partials/footer.php'; ?>

--- a/admin/category-form.php
+++ b/admin/category-form.php
@@ -1,0 +1,8 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-4">Category Form</h1>
+<form>
+  <div class="mb-3"><label class="form-label">Name</label><input type="text" class="form-control"></div>
+  <div class="mb-3"><label class="form-label">Description</label><textarea class="form-control"></textarea></div>
+  <button class="btn btn-primary">Save Category</button>
+</form>
+<?php include 'partials/footer.php'; ?>

--- a/admin/charts.php
+++ b/admin/charts.php
@@ -1,0 +1,34 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-4">Charts</h1>
+<div class="chart-filter btn-group mb-4" role="group">
+  <button class="btn btn-outline-primary active">Week</button>
+  <button class="btn btn-outline-primary">Month</button>
+  <button class="btn btn-outline-primary">Year</button>
+</div>
+<div class="row g-4">
+  <div class="col-md-6">
+    <div class="card p-3">
+      <h5>Sales Over Time</h5>
+      <canvas id="salesChart" height="200"></canvas>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card p-3">
+      <h5>Orders by Status</h5>
+      <canvas id="ordersStatusChart" height="200"></canvas>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card p-3">
+      <h5>Top Selling Products</h5>
+      <canvas id="topProductsChart" height="200"></canvas>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card p-3">
+      <h5>Customers by Country</h5>
+      <canvas id="customersChart" height="200"></canvas>
+    </div>
+  </div>
+</div>
+<?php include 'partials/footer.php'; ?>

--- a/admin/customer-detail.php
+++ b/admin/customer-detail.php
@@ -1,0 +1,23 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-4">Customer: John Doe</h1>
+<div class="row mb-4">
+  <div class="col-md-6">
+    <div class="card p-3">
+      <h5>Contact</h5>
+      <p>Email: john@example.com<br>Phone: 123456789</p>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card p-3">
+      <h5>Orders</h5>
+      <p>Total Orders: 5<br>Total Spent: $500</p>
+    </div>
+  </div>
+</div>
+<div class="card p-3">
+  <h5>Recent Orders</h5>
+  <table class="table"><thead><tr><th>#</th><th>Status</th><th>Total</th></tr></thead>
+    <tbody><tr><td>1001</td><td>Pending</td><td>$99</td></tr></tbody>
+  </table>
+</div>
+<?php include 'partials/footer.php'; ?>

--- a/admin/customers.php
+++ b/admin/customers.php
@@ -1,0 +1,9 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-3">Customers</h1>
+<table class="table table-bordered table-striped">
+  <thead><tr><th>ID</th><th>Name</th><th>Email</th><th></th></tr></thead>
+  <tbody>
+    <tr><td>1</td><td>John Doe</td><td>john@example.com</td><td><a href="customer-detail.php" class="btn btn-sm btn-secondary">View</a></td></tr>
+  </tbody>
+</table>
+<?php include 'partials/footer.php'; ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,62 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="mb-4">Dashboard</h1>
+<div class="row g-4 mb-4">
+  <div class="col-md-3">
+    <div class="card text-center p-3">
+      <h5>Orders</h5>
+      <p class="display-6">120</p>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-center p-3">
+      <h5>Revenue</h5>
+      <p class="display-6">$3,200</p>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-center p-3">
+      <h5>Customers</h5>
+      <p class="display-6">85</p>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-center p-3">
+      <h5>Products</h5>
+      <p class="display-6">240</p>
+    </div>
+  </div>
+</div>
+<div class="row g-4">
+  <div class="col-lg-8">
+    <div class="card p-3">
+      <h5>Sales Overview</h5>
+      <canvas id="salesChart" height="150"></canvas>
+    </div>
+  </div>
+  <div class="col-lg-4">
+    <div class="card p-3 mb-4">
+      <h5>Orders by Status</h5>
+      <canvas id="ordersStatusChart" height="150"></canvas>
+    </div>
+    <div class="card p-3">
+      <h5>Top Products</h5>
+      <canvas id="topProductsChart" height="150"></canvas>
+    </div>
+  </div>
+</div>
+<div class="row mt-4">
+  <div class="col-12">
+    <div class="card p-3">
+      <h5>Recent Orders</h5>
+      <table class="table table-striped">
+        <thead><tr><th>#</th><th>Customer</th><th>Status</th><th>Total</th></tr></thead>
+        <tbody>
+          <tr><td>1001</td><td>John Doe</td><td><span class="badge bg-warning">Pending</span></td><td>$99</td></tr>
+          <tr><td>1002</td><td>Jane Smith</td><td><span class="badge bg-success">Completed</span></td><td>$150</td></tr>
+          <tr><td>1003</td><td>Bob Lee</td><td><span class="badge bg-info">Shipped</span></td><td>$200</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<?php include 'partials/footer.php'; ?>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Login - WoskiCart</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/custom.css">
+</head>
+<body class="d-flex align-items-center justify-content-center" style="min-height:100vh;">
+  <div class="card shadow" style="min-width:300px;">
+    <div class="card-body">
+      <h3 class="card-title mb-4 text-center">WoskiCart Admin</h3>
+      <form>
+        <div class="mb-3">
+          <label class="form-label">Email</label>
+          <input type="email" class="form-control" placeholder="admin@example.com">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Password</label>
+          <input type="password" class="form-control" placeholder="••••••">
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Login</button>
+      </form>
+    </div>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="assets/js/script.js"></script>
+</body>
+</html>

--- a/admin/order-detail.php
+++ b/admin/order-detail.php
@@ -1,0 +1,23 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-4">Order #1001</h1>
+<div class="row mb-4">
+  <div class="col-md-6">
+    <div class="card p-3">
+      <h5>Customer</h5>
+      <p>John Doe<br>john@example.com</p>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card p-3">
+      <h5>Order Info</h5>
+      <p>Status: <span class="badge bg-warning">Pending</span><br>Total: $99</p>
+    </div>
+  </div>
+</div>
+<div class="card p-3">
+  <h5>Items</h5>
+  <table class="table"><thead><tr><th>Product</th><th>Qty</th><th>Price</th></tr></thead>
+    <tbody><tr><td>Sample Product</td><td>1</td><td>$99</td></tr></tbody>
+  </table>
+</div>
+<?php include 'partials/footer.php'; ?>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1,0 +1,9 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-3">Orders</h1>
+<table class="table table-bordered table-striped">
+  <thead><tr><th>ID</th><th>Customer</th><th>Status</th><th>Total</th><th></th></tr></thead>
+  <tbody>
+    <tr><td>1001</td><td>John Doe</td><td><span class="badge bg-warning">Pending</span></td><td>$99</td><td><a href="order-detail.php" class="btn btn-sm btn-secondary">View</a></td></tr>
+  </tbody>
+</table>
+<?php include 'partials/footer.php'; ?>

--- a/admin/partials/footer.php
+++ b/admin/partials/footer.php
@@ -1,0 +1,9 @@
+    </div>
+  </div>
+  <div class="alerts-container"></div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="assets/js/script.js"></script>
+</body>
+</html>

--- a/admin/partials/header.php
+++ b/admin/partials/header.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WoskiCart Admin</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/custom.css">
+</head>
+<body>
+  <div class="d-flex" id="wrapper">
+    <?php include 'partials/sidebar.php'; ?>
+    <div id="page-content-wrapper" class="flex-grow-1">
+      <?php include 'partials/navbar.php'; ?>
+      <div class="container-fluid py-4">

--- a/admin/partials/navbar.php
+++ b/admin/partials/navbar.php
@@ -1,0 +1,27 @@
+<nav class="navbar navbar-expand-lg navbar-dark px-3">
+  <button class="btn btn-outline-light me-2" id="sidebarToggle"><i class="bi bi-list"></i></button>
+  <a class="navbar-brand" href="#">WoskiCart</a>
+  <div class="collapse navbar-collapse">
+    <ul class="navbar-nav ms-auto align-items-center">
+      <li class="nav-item dropdown theme-switcher">
+        <a class="nav-link dropdown-toggle" href="#" id="themeDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          Theme
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="themeDropdown">
+          <li><span class="dropdown-item" data-theme="default">Default</span></li>
+          <li><span class="dropdown-item" data-theme="dark">Dark</span></li>
+          <li><span class="dropdown-item" data-theme="custom">Custom</span></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          <i class="bi bi-person-circle"></i>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="profileDropdown">
+          <li><a class="dropdown-item" href="#">Profile</a></li>
+          <li><a class="dropdown-item" href="#">Logout</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/admin/partials/sidebar.php
+++ b/admin/partials/sidebar.php
@@ -1,0 +1,19 @@
+<div class="sidebar" id="sidebar">
+  <div class="p-3">
+    <h2 class="text-white">WoskiCart</h2>
+    <ul class="nav flex-column mt-4">
+      <li class="nav-item"><a class="nav-link" href="index.php"><i class="bi bi-speedometer2 me-2"></i>Dashboard</a></li>
+      <li class="nav-item"><a class="nav-link" href="products.php"><i class="bi bi-box-seam me-2"></i>Products</a></li>
+      <li class="nav-item"><a class="nav-link" href="categories.php"><i class="bi bi-folder me-2"></i>Categories</a></li>
+      <li class="nav-item"><a class="nav-link" href="tags.php"><i class="bi bi-tag me-2"></i>Tags</a></li>
+      <li class="nav-item"><a class="nav-link" href="orders.php"><i class="bi bi-receipt me-2"></i>Orders</a></li>
+      <li class="nav-item"><a class="nav-link" href="customers.php"><i class="bi bi-people me-2"></i>Customers</a></li>
+      <li class="nav-item"><a class="nav-link" href="reviews.php"><i class="bi bi-chat-left-text me-2"></i>Reviews</a></li>
+      <li class="nav-item"><a class="nav-link" href="transactions.php"><i class="bi bi-credit-card me-2"></i>Transactions</a></li>
+      <li class="nav-item"><a class="nav-link" href="charts.php"><i class="bi bi-graph-up me-2"></i>Charts</a></li>
+      <li class="nav-item"><a class="nav-link" href="ui-components.php"><i class="bi bi-layers me-2"></i>UI Components</a></li>
+      <li class="nav-item"><a class="nav-link" href="settings.php"><i class="bi bi-gear me-2"></i>Settings</a></li>
+      <li class="nav-item"><a class="nav-link" href="boilerplate.php"><i class="bi bi-file-earmark me-2"></i>Boilerplate</a></li>
+    </ul>
+  </div>
+</div>

--- a/admin/product-form.php
+++ b/admin/product-form.php
@@ -1,0 +1,29 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-4">Product Form</h1>
+<ul class="nav nav-tabs" id="productTab" role="tablist">
+  <li class="nav-item" role="presentation"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#general" type="button">General</button></li>
+  <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#images" type="button">Images</button></li>
+  <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#variants" type="button">Variants</button></li>
+  <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#meta" type="button">Meta</button></li>
+</ul>
+<div class="tab-content border border-top-0 p-3" id="productTabContent">
+  <div class="tab-pane fade show active" id="general" role="tabpanel">
+    <div class="mb-3"><label class="form-label">Name</label><input type="text" class="form-control"></div>
+    <div class="mb-3"><label class="form-label">Price</label><input type="number" class="form-control"></div>
+    <div class="mb-3"><label class="form-label">Description</label><textarea class="form-control"></textarea></div>
+  </div>
+  <div class="tab-pane fade" id="images" role="tabpanel">
+    <div class="mb-3"><label class="form-label">Upload Images</label><input type="file" class="form-control" multiple></div>
+  </div>
+  <div class="tab-pane fade" id="variants" role="tabpanel">
+    <p>Variant options placeholder.</p>
+  </div>
+  <div class="tab-pane fade" id="meta" role="tabpanel">
+    <div class="mb-3"><label class="form-label">Meta Title</label><input type="text" class="form-control"></div>
+    <div class="mb-3"><label class="form-label">Meta Description</label><textarea class="form-control"></textarea></div>
+  </div>
+</div>
+<div class="mt-3">
+  <button class="btn btn-primary">Save Product</button>
+</div>
+<?php include 'partials/footer.php'; ?>

--- a/admin/products.php
+++ b/admin/products.php
@@ -1,0 +1,12 @@
+<?php include 'partials/header.php'; ?>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3">Products</h1>
+  <a href="product-form.php" class="btn btn-primary">Add Product</a>
+</div>
+<table class="table table-bordered table-striped">
+  <thead><tr><th>ID</th><th>Name</th><th>Price</th><th>Status</th><th></th></tr></thead>
+  <tbody>
+    <tr><td>1</td><td>Sample Product</td><td>$19.99</td><td><span class="badge bg-success">Active</span></td><td><a href="product-form.php" class="btn btn-sm btn-secondary">Edit</a></td></tr>
+  </tbody>
+</table>
+<?php include 'partials/footer.php'; ?>

--- a/admin/reviews.php
+++ b/admin/reviews.php
@@ -1,0 +1,9 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-3">Reviews</h1>
+<table class="table table-bordered table-striped">
+  <thead><tr><th>ID</th><th>Product</th><th>Customer</th><th>Rating</th><th>Review</th></tr></thead>
+  <tbody>
+    <tr><td>1</td><td>Sample Product</td><td>John Doe</td><td>5</td><td>Great!</td></tr>
+  </tbody>
+</table>
+<?php include 'partials/footer.php'; ?>

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -1,0 +1,32 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-4">Settings</h1>
+<ul class="nav nav-tabs" id="settingsTab" role="tablist">
+  <li class="nav-item" role="presentation"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#general" type="button">General</button></li>
+  <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#stock" type="button">Stock</button></li>
+  <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#checkout" type="button">Checkout</button></li>
+  <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#payments" type="button">Payments</button></li>
+  <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#routes" type="button">Routes</button></li>
+  <li class="nav-item" role="presentation"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#appearance" type="button">Appearance</button></li>
+</ul>
+<div class="tab-content border border-top-0 p-3" id="settingsTabContent">
+  <div class="tab-pane fade show active" id="general" role="tabpanel"><p>General settings form.</p></div>
+  <div class="tab-pane fade" id="stock" role="tabpanel"><p>Stock settings form.</p></div>
+  <div class="tab-pane fade" id="checkout" role="tabpanel"><p>Checkout settings form.</p></div>
+  <div class="tab-pane fade" id="payments" role="tabpanel"><p>Payments settings form.</p></div>
+  <div class="tab-pane fade" id="routes" role="tabpanel"><p>Routes settings form.</p></div>
+  <div class="tab-pane fade" id="appearance" role="tabpanel">
+    <div class="mb-3">
+      <label class="form-label">Theme</label>
+      <div class="dropdown theme-switcher">
+        <button class="btn btn-secondary dropdown-toggle" type="button" id="appearanceThemeDropdown" data-bs-toggle="dropdown">Select Theme</button>
+        <ul class="dropdown-menu" aria-labelledby="appearanceThemeDropdown">
+          <li><span class="dropdown-item" data-theme="default">Default</span></li>
+          <li><span class="dropdown-item" data-theme="dark">Dark</span></li>
+          <li><span class="dropdown-item" data-theme="custom">Custom</span></li>
+        </ul>
+      </div>
+    </div>
+    <p>Custom theme colors can be adjusted via <code>custom.css</code>.</p>
+  </div>
+</div>
+<?php include 'partials/footer.php'; ?>

--- a/admin/tag-form.php
+++ b/admin/tag-form.php
@@ -1,0 +1,7 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-4">Tag Form</h1>
+<form>
+  <div class="mb-3"><label class="form-label">Name</label><input type="text" class="form-control"></div>
+  <button class="btn btn-primary">Save Tag</button>
+</form>
+<?php include 'partials/footer.php'; ?>

--- a/admin/tags.php
+++ b/admin/tags.php
@@ -1,0 +1,12 @@
+<?php include 'partials/header.php'; ?>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3">Tags</h1>
+  <a href="tag-form.php" class="btn btn-primary">Add Tag</a>
+</div>
+<table class="table table-bordered table-striped">
+  <thead><tr><th>ID</th><th>Name</th><th></th></tr></thead>
+  <tbody>
+    <tr><td>1</td><td>New</td><td><a href="tag-form.php" class="btn btn-sm btn-secondary">Edit</a></td></tr>
+  </tbody>
+</table>
+<?php include 'partials/footer.php'; ?>

--- a/admin/transaction-detail.php
+++ b/admin/transaction-detail.php
@@ -1,0 +1,17 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-4">Transaction #1</h1>
+<div class="row mb-4">
+  <div class="col-md-6">
+    <div class="card p-3">
+      <h5>Payment Info</h5>
+      <p>Method: Credit Card<br>Status: <span class="badge bg-success">Paid</span></p>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card p-3">
+      <h5>Order</h5>
+      <p>Order ID: #1001<br>Total: $99</p>
+    </div>
+  </div>
+</div>
+<?php include 'partials/footer.php'; ?>

--- a/admin/transactions.php
+++ b/admin/transactions.php
@@ -1,0 +1,9 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-3">Transactions</h1>
+<table class="table table-bordered table-striped">
+  <thead><tr><th>ID</th><th>Order</th><th>Amount</th><th>Status</th><th></th></tr></thead>
+  <tbody>
+    <tr><td>1</td><td>#1001</td><td>$99</td><td><span class="badge bg-success">Paid</span></td><td><a href="transaction-detail.php" class="btn btn-sm btn-secondary">View</a></td></tr>
+  </tbody>
+</table>
+<?php include 'partials/footer.php'; ?>

--- a/admin/ui-components.php
+++ b/admin/ui-components.php
@@ -1,0 +1,57 @@
+<?php include 'partials/header.php'; ?>
+<h1 class="h3 mb-4">UI Components</h1>
+<section class="mb-5">
+  <h5>Buttons</h5>
+  <button class="btn btn-primary me-2">Primary</button>
+  <button class="btn btn-secondary me-2">Secondary</button>
+  <button class="btn btn-success me-2">Success</button>
+  <button class="btn btn-danger">Danger</button>
+</section>
+<section class="mb-5">
+  <h5>Forms</h5>
+  <form class="row g-3">
+    <div class="col-md-6"><label class="form-label">Email</label><input type="email" class="form-control" placeholder="email@example.com"></div>
+    <div class="col-md-6"><label class="form-label">Password</label><input type="password" class="form-control" placeholder="Password"></div>
+    <div class="col-12"><label class="form-label">Address</label><input type="text" class="form-control" placeholder="1234 Main St"></div>
+    <div class="col-12"><button class="btn btn-primary">Submit</button></div>
+  </form>
+</section>
+<section class="mb-5">
+  <h5>Tables</h5>
+  <table class="table table-striped"><thead><tr><th>#</th><th>Name</th><th>Value</th></tr></thead><tbody><tr><td>1</td><td>Item</td><td>100</td></tr></tbody></table>
+</section>
+<section class="mb-5">
+  <h5>Alerts</h5>
+  <button class="btn btn-success alert-trigger me-2" data-type="success">Success Alert</button>
+  <button class="btn btn-danger alert-trigger" data-type="danger">Error Alert</button>
+</section>
+<section class="mb-5">
+  <h5>Modals</h5>
+  <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#demoModal">Open Modal</button>
+  <div class="modal fade" id="demoModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog"><div class="modal-content"><div class="modal-header"><h5 class="modal-title">Modal title</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div><div class="modal-body">Modal body text</div><div class="modal-footer"><button class="btn btn-secondary" data-bs-dismiss="modal">Close</button><button class="btn btn-primary">Save changes</button></div></div></div>
+  </div>
+</section>
+<section class="mb-5">
+  <h5>Badges</h5>
+  <span class="badge bg-primary">Primary</span>
+  <span class="badge bg-success">Success</span>
+  <span class="badge bg-danger">Danger</span>
+</section>
+<section class="mb-5">
+  <h5>Cards</h5>
+  <div class="card p-3">Example card with text.</div>
+</section>
+<section class="mb-5">
+  <h5>Sample Chart</h5>
+  <canvas id="componentsChart" height="100"></canvas>
+</section>
+<script>
+if(document.getElementById('componentsChart')){
+  new Chart(document.getElementById('componentsChart'),{
+    type:'line',
+    data:{labels:['A','B','C'],datasets:[{label:'Data',data:[3,1,4],borderColor:'rgba(13,110,253,0.5)'}]}
+  });
+}
+</script>
+<?php include 'partials/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Add responsive PHP admin dashboard with glossy sidebar, navbar and reusable partials
- Implement theme system with default, dark and custom modes stored in localStorage
- Include Chart.js examples, tables, forms and UI reference pages

## Testing
- `find admin -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68c4432bd89083248c1e6e7c41f4ef45